### PR TITLE
README: add an archive.org link to project

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Jtalk-Rack
 
-This is a Rack app that serves [Jtalk](http://jtalk-project.org/) and
+This is a Rack app that serves [Jtalk](http://jtalk-project.org/)
+([jtalk-project.org in 2011]) and
 saves code via [RackDAV](https://github.com/georgi/rack_dav).
 
 
@@ -17,3 +18,5 @@ Then, start up the server:
 (A shortcut for those last two commands is: `rake && rake`)
 
 Now open http://localhost:9292 in a browser.
+
+[jtalk-project.org in 2011]: https://web.archive.org/web/20110723231233/http://jtalk-project.org/


### PR DESCRIPTION
This PR adds a link to the README to point to the JTalk Project, now turned into [Amber.](https://amber-lang.net/)